### PR TITLE
Add media utilities and link preview service

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,5 +1,5 @@
 """API routers."""
 
-from . import auth, payments, subscriptions
+from . import auth, payments, subscriptions, link_preview
 
-__all__ = ["auth", "payments", "subscriptions"]
+__all__ = ["auth", "payments", "subscriptions", "link_preview"]

--- a/backend/app/api/link_preview.py
+++ b/backend/app/api/link_preview.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, HTTPException, Query
+
+from app.services.link_preview import fetch_link_preview
+
+router = APIRouter(prefix="/link-preview", tags=["link-preview"])
+
+
+@router.get("/")
+async def generate_link_preview(url: str = Query(..., description="URL to preview")):
+    try:
+        return await fetch_link_preview(url)
+    except Exception as exc:  # pragma: no cover - simple pass-through
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 
 from .core.config import settings
 
-from .api import auth, payments, subscriptions
+from .api import auth, payments, subscriptions, link_preview
 
 
 app = FastAPI(title="Layer01 API")
@@ -11,6 +11,7 @@ app = FastAPI(title="Layer01 API")
 app.include_router(auth.router)
 app.include_router(subscriptions.router, prefix="/api/v1")
 app.include_router(payments.router, prefix="/api/v1")
+app.include_router(link_preview.router, prefix="/api/v1")
 
 
 @app.get("/")

--- a/backend/app/services/link_preview.py
+++ b/backend/app/services/link_preview.py
@@ -1,0 +1,18 @@
+import re
+import httpx
+
+async def fetch_link_preview(url: str) -> dict[str, str]:
+    """Fetch basic metadata for a URL for preview purposes."""
+    async with httpx.AsyncClient(follow_redirects=True, timeout=10) as client:
+        resp = await client.get(url)
+        text = resp.text
+
+    def _search(pattern: str) -> str | None:
+        m = re.search(pattern, text, re.IGNORECASE | re.DOTALL)
+        return m.group(1).strip() if m else None
+
+    title = _search(r"<title[^>]*>(.*?)</title>") or ""
+    description = _search(r'<meta[^>]+name=["\']description["\'][^>]+content=["\'](.*?)["\']') or ""
+    image = _search(r'<meta[^>]+property=["\']og:image["\'][^>]+content=["\'](.*?)["\']') or ""
+
+    return {"title": title, "description": description, "image": image, "url": url}

--- a/frontend/app/(dashboard)/posts/page.tsx
+++ b/frontend/app/(dashboard)/posts/page.tsx
@@ -1,0 +1,19 @@
+import { PdfViewer } from '../../../lib/pdf';
+import VideoPlayer from '../../../components/VideoPlayer';
+import GifPlayer from '../../../components/GifPlayer';
+import LinkPreview from '../../../components/LinkPreview';
+
+export default function PostsPage() {
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">Embed Media</h1>
+      <PdfViewer
+        src="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
+        pages={1}
+      />
+      <VideoPlayer src="https://www.w3schools.com/html/mov_bbb.mp4" />
+      <GifPlayer src="https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif" alt="Cat" />
+      <LinkPreview url="https://example.com" />
+    </div>
+  );
+}

--- a/frontend/components/GifPlayer.tsx
+++ b/frontend/components/GifPlayer.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+interface GifPlayerProps {
+  src: string;
+  alt?: string;
+}
+
+export default function GifPlayer({ src, alt }: GifPlayerProps) {
+  return <img src={src} alt={alt ?? 'gif'} className="w-full" />;
+}

--- a/frontend/components/LinkPreview.tsx
+++ b/frontend/components/LinkPreview.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface PreviewData {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+}
+
+export default function LinkPreview({ url }: { url: string }) {
+  const [data, setData] = useState<PreviewData | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/v1/link-preview?url=${encodeURIComponent(url)}`)
+      .then((res) => res.json())
+      .then((d) => setData(d))
+      .catch(() => setData(null));
+  }, [url]);
+
+  if (!data) return null;
+
+  return (
+    <a href={data.url} className="block border p-4">
+      {data.image && <img src={data.image} alt={data.title} className="mb-2" />}
+      <h3 className="font-bold">{data.title}</h3>
+      <p>{data.description}</p>
+    </a>
+  );
+}

--- a/frontend/components/VideoPlayer.tsx
+++ b/frontend/components/VideoPlayer.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+interface VideoPlayerProps {
+  src: string;
+}
+
+export default function VideoPlayer({ src }: VideoPlayerProps) {
+  return (
+    <video src={src} controls autoPlay loop muted className="w-full" />
+  );
+}

--- a/frontend/lib/pdf.tsx
+++ b/frontend/lib/pdf.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useRef } from 'react';
+
+interface PdfViewerProps {
+  src: string;
+  pages: number;
+}
+
+export function PdfViewer({ src, pages }: PdfViewerProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const goToPage = (p: number) => {
+    if (iframeRef.current) {
+      iframeRef.current.src = `${src}#page=${p}&toolbar=0`;
+    }
+  };
+
+  return (
+    <div className="flex">
+      <nav className="mr-4">
+        <ul>
+          {Array.from({ length: pages }, (_, i) => (
+            <li key={i}>
+              <button onClick={() => goToPage(i + 1)} className="underline">
+                Page {i + 1}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <iframe
+        ref={iframeRef}
+        src={`${src}#toolbar=0`}
+        className="flex-1 h-screen"
+        title="PDF document"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add PDF viewer utility with page navigation
- integrate autoplay video and GIF components
- expose link preview service via API
- demo media embedding in posts page

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bfbb8888333a303895041133cd4