### PR TITLE
Add real-time messaging and dashboard chat UI

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,5 +1,5 @@
 """API routers."""
 
-from . import auth, payments, subscriptions
+from . import auth, payments, subscriptions, messages
 
-__all__ = ["auth", "payments", "subscriptions"]
+__all__ = ["auth", "payments", "subscriptions", "messages"]

--- a/backend/app/api/messages.py
+++ b/backend/app/api/messages.py
@@ -1,0 +1,54 @@
+import asyncio
+import json
+
+from fastapi import APIRouter, Depends
+from sse_starlette.sse import EventSourceResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.models.message import Message
+from app.schemas.message import MessageCreate, MessageRead
+
+router = APIRouter(prefix="/messages", tags=["messages"])
+
+listeners: list[asyncio.Queue] = []
+
+
+@router.get("/", response_model=list[MessageRead])
+async def get_messages(session: AsyncSession = Depends(get_session)) -> list[MessageRead]:
+    result = await session.execute(select(Message).order_by(Message.id))
+    return [MessageRead.from_orm(m) for m in result.scalars().all()]
+
+
+@router.post("/", response_model=MessageRead)
+async def send_message(
+    data: MessageCreate, session: AsyncSession = Depends(get_session)
+) -> MessageRead:
+    message = Message(**data.dict())
+    session.add(message)
+    await session.commit()
+    await session.refresh(message)
+    message_read = MessageRead.from_orm(message)
+    for queue in listeners:
+        await queue.put(message_read.dict())
+    return message_read
+
+
+@router.get("/stream")
+async def stream() -> EventSourceResponse:
+    queue: asyncio.Queue = asyncio.Queue()
+    listeners.append(queue)
+
+    async def event_generator():
+        try:
+            while True:
+                data = await queue.get()
+                yield {
+                    "event": "message",
+                    "data": json.dumps(data),
+                }
+        finally:
+            listeners.remove(queue)
+
+    return EventSourceResponse(event_generator())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 
 from .core.config import settings
 
-from .api import auth, payments, subscriptions
+from .api import auth, payments, subscriptions, messages
 
 
 app = FastAPI(title="Layer01 API")
@@ -11,6 +11,7 @@ app = FastAPI(title="Layer01 API")
 app.include_router(auth.router)
 app.include_router(subscriptions.router, prefix="/api/v1")
 app.include_router(payments.router, prefix="/api/v1")
+app.include_router(messages.router, prefix="/api/v1")
 
 
 @app.get("/")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,5 +3,6 @@ from .channel import Channel
 from .plan import Plan
 from .subscription import Subscription
 from .payment_event import PaymentEvent
+from .message import Message
 
-__all__ = ["User", "Channel", "Plan", "Subscription", "PaymentEvent"]
+__all__ = ["User", "Channel", "Plan", "Subscription", "PaymentEvent", "Message"]

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Boolean, String, Text, DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    pinned: Mapped[bool] = mapped_column(Boolean, default=False)
+    attachment: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[DateTime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class MessageBase(BaseModel):
+    content: str
+    pinned: bool = False
+    attachment: str | None = None
+
+
+class MessageCreate(MessageBase):
+    pass
+
+
+class MessageRead(MessageBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/migrations/versions/0003_create_messages.py
+++ b/backend/migrations/versions/0003_create_messages.py
@@ -1,0 +1,23 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("pinned", sa.Boolean, nullable=False, server_default=sa.false()),
+        sa.Column("attachment", sa.String(255)),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("messages")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ passlib[bcrypt]
 httpx
 aiosqlite
 email-validator
+sse-starlette

--- a/frontend/app/(dashboard)/chat/page.tsx
+++ b/frontend/app/(dashboard)/chat/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Message {
+  id: number;
+  content: string;
+  pinned: boolean;
+  attachment?: string | null;
+  reactions?: Record<string, number>;
+}
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+
+  useEffect(() => {
+    fetch("/api/v1/messages").then(res => res.json()).then(setMessages);
+    const es = new EventSource("/api/v1/messages/stream");
+    es.onmessage = (event) => {
+      const data: Message = JSON.parse(event.data);
+      setMessages(prev => [...prev, data]);
+    };
+    return () => es.close();
+  }, []);
+
+  const sendMessage = async () => {
+    await fetch("/api/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: input }),
+    });
+    setInput("");
+  };
+
+  const addReaction = (id: number, emoji: string) => {
+    setMessages(msgs =>
+      msgs.map(m =>
+        m.id === id
+          ? {
+              ...m,
+              reactions: { ...m.reactions, [emoji]: (m.reactions?.[emoji] || 0) + 1 },
+            }
+          : m
+      )
+    );
+  };
+
+  return (
+    <div className="p-4">
+      <div className="space-y-2">
+        {messages.map(m => (
+          <div key={m.id} className="border p-2">
+            <p>{m.content}</p>
+            <div className="space-x-2 mt-1">
+              {['👍', '❤️', '😂'].map(e => (
+                <button key={e} onClick={() => addReaction(m.id, e)}>
+                  {e} {m.reactions?.[e] || 0}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 flex space-x-2">
+        <input
+          className="border flex-1 p-1"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Type a message"
+        />
+        <button onClick={sendMessage}>Send</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `messages` API with SSE stream for real-time chat
- persist chat messages with pin and attachment fields
- create dashboard chat page with emoji reactions

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bfb05408333a71434d82c7edeb8