### PR TITLE
Implement subscription management and frontend purchase flow

### DIFF
--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -37,3 +37,13 @@ class IamportWebhook(BaseModel):
     status: str
     imp_uid: str | None = None
     # Add any additional fields you require from Iamport webhook payload
+
+
+class SubscriptionVerify(BaseModel):
+    merchant_uid: str
+    imp_uid: str | None = None
+
+
+class SubscriptionUpdate(BaseModel):
+    status: str | None = None
+    current_period_end: datetime | None = None

--- a/backend/tests/test_subscription.py
+++ b/backend/tests/test_subscription.py
@@ -56,6 +56,10 @@ def test_plan_and_subscription_flow():
     assert r.status_code == 200
     plan_id = r.json()["id"]
 
+    r_list = client.get(f"/api/v1/subscriptions/plans/1")
+    assert r_list.status_code == 200
+    assert len(r_list.json()) == 1
+
     subscriber_headers = _auth_header("sub@example.com")
     r2 = client.post(
         "/api/v1/subscriptions/",
@@ -63,11 +67,34 @@ def test_plan_and_subscription_flow():
         headers=subscriber_headers,
     )
     assert r2.status_code == 200
+    assert r2.json()["status"] == "pending"
     merchant_uid = r2.json()["merchant_uid"]
+    sub_id = r2.json()["id"]
 
-    r3 = client.post(
-        "/api/v1/payments/iamport-webhook",
-        json={"merchant_uid": merchant_uid, "status": "paid"},
-        headers={"X-Iamport-Signature": "whsec"},
+    r_verify = client.post(
+        "/api/v1/subscriptions/verify-payment",
+        json={"merchant_uid": merchant_uid},
     )
-    assert r3.status_code == 200
+    assert r_verify.status_code == 200
+    assert r_verify.json()["status"] == "active"
+
+    new_date = "2030-01-01T00:00:00"
+    r_update = client.put(
+        f"/api/v1/subscriptions/{sub_id}",
+        json={"current_period_end": new_date},
+        headers=subscriber_headers,
+    )
+    assert r_update.status_code == 200
+    assert r_update.json()["current_period_end"].startswith("2030-01-01")
+
+    r_me = client.get("/api/v1/subscriptions/me", headers=subscriber_headers)
+    assert r_me.status_code == 200
+    assert r_me.json()["status"] == "active"
+
+
+def test_verify_payment_failure():
+    r = client.post(
+        "/api/v1/subscriptions/verify-payment",
+        json={"merchant_uid": "missing"},
+    )
+    assert r.status_code == 404

--- a/frontend/app/(dashboard)/subscriptions/page.tsx
+++ b/frontend/app/(dashboard)/subscriptions/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Plan {
+  id: number;
+  price: number;
+}
+
+export default function SubscriptionPage() {
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch('/api/v1/subscriptions/plans/1')
+      .then((res) => res.json())
+      .then(setPlans)
+      .catch(() => setError('Failed to load plans'));
+  }, []);
+
+  const purchase = async (planId: number) => {
+    const res = await fetch('/api/v1/subscriptions/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan_id: planId }),
+    });
+    if (!res.ok) {
+      alert('Failed to purchase');
+      return;
+    }
+    const data = await res.json();
+    await fetch('/api/v1/subscriptions/verify-payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ merchant_uid: data.merchant_uid }),
+    });
+    alert('Subscription active');
+  };
+
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Plans</h1>
+      {error && <p>{error}</p>}
+      <ul>
+        {plans.map((p) => (
+          <li key={p.id} className="mb-2">
+            {p.price} <button onClick={() => purchase(p.id)}>Buy</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expand subscription API with plan listing, payment verification, status and renewal endpoints
- add dashboard subscription page to view plans and initiate purchases
- cover successful and failing subscription scenarios in tests

## Testing
- `pytest backend/tests -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab4bfaa37483338bc43c4cfe20c945