### PR TITLE
Add CRUD endpoints for channels and posts with subscriber checks

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,5 +1,5 @@
 """API routers."""
 
-from . import auth, payments, subscriptions
+from . import auth, payments, subscriptions, channels, posts
 
-__all__ = ["auth", "payments", "subscriptions"]
+__all__ = ["auth", "payments", "subscriptions", "channels", "posts"]

--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.security import require_role, require_subscriber
+from app.core.database import get_session
+from app.models.channel import Channel
+from app.schemas.channel import ChannelCreate, ChannelRead
+
+router = APIRouter(prefix="/channels", tags=["channels"])
+
+
+@router.get("/", response_model=list[ChannelRead])
+async def list_channels(
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_subscriber),
+):
+    result = await session.execute(select(Channel))
+    return result.scalars().all()
+
+
+@router.post("/", response_model=ChannelRead)
+async def create_channel(
+    payload: ChannelCreate,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("creator")),
+):
+    channel = Channel(creator_id=user.id, **payload.dict())
+    session.add(channel)
+    await session.commit()
+    await session.refresh(channel)
+    return channel
+
+
+@router.put("/{channel_id}", response_model=ChannelRead)
+async def update_channel(
+    channel_id: int,
+    payload: ChannelCreate,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("creator")),
+):
+    channel = await session.get(Channel, channel_id)
+    if channel is None or channel.creator_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Channel not found")
+    for field, value in payload.dict().items():
+        setattr(channel, field, value)
+    await session.commit()
+    await session.refresh(channel)
+    return channel
+
+
+@router.delete("/{channel_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_channel(
+    channel_id: int,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("creator")),
+):
+    channel = await session.get(Channel, channel_id)
+    if channel is None or channel.creator_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Channel not found")
+    await session.delete(channel)
+    await session.commit()

--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.security import require_role, require_subscriber
+from app.core.database import get_session
+from app.models.post import Post
+from app.schemas.post import PostCreate, PostRead
+
+router = APIRouter(prefix="/posts", tags=["posts"])
+
+
+@router.get("/", response_model=list[PostRead])
+async def list_posts(
+    post_type: str | None = None,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_subscriber),
+):
+    query = select(Post)
+    if post_type:
+        query = query.where(Post.type == post_type)
+    result = await session.execute(query)
+    return result.scalars().all()
+
+
+@router.post("/", response_model=PostRead)
+async def create_post(
+    payload: PostCreate,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("creator")),
+):
+    post = Post(**payload.dict(), author_id=user.id)
+    session.add(post)
+    await session.commit()
+    await session.refresh(post)
+    return post
+
+
+@router.put("/{post_id}", response_model=PostRead)
+async def update_post(
+    post_id: int,
+    payload: PostCreate,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("creator")),
+):
+    post = await session.get(Post, post_id)
+    if post is None or post.author_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Post not found")
+    for field, value in payload.dict().items():
+        setattr(post, field, value)
+    await session.commit()
+    await session.refresh(post)
+    return post
+
+
+@router.delete("/{post_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_post(
+    post_id: int,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("creator")),
+):
+    post = await session.get(Post, post_id)
+    if post is None or post.author_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Post not found")
+    await session.delete(post)
+    await session.commit()

--- a/backend/app/auth/security.py
+++ b/backend/app/auth/security.py
@@ -62,3 +62,12 @@ def require_role(role: str):
         return user
 
     return checker
+
+
+async def require_subscriber(
+    user: Annotated[User, Depends(get_current_user)]
+) -> User:
+    """Allow access only to subscribers and creators."""
+    if user.role not in ("subscriber", "creator"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    return user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 
 from .core.config import settings
 
-from .api import auth, payments, subscriptions
+from .api import auth, payments, subscriptions, channels, posts
 
 
 app = FastAPI(title="Layer01 API")
@@ -11,6 +11,8 @@ app = FastAPI(title="Layer01 API")
 app.include_router(auth.router)
 app.include_router(subscriptions.router, prefix="/api/v1")
 app.include_router(payments.router, prefix="/api/v1")
+app.include_router(channels.router, prefix="/api/v1")
+app.include_router(posts.router, prefix="/api/v1")
 
 
 @app.get("/")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,5 +3,6 @@ from .channel import Channel
 from .plan import Plan
 from .subscription import Subscription
 from .payment_event import PaymentEvent
+from .post import Post
 
-__all__ = ["User", "Channel", "Plan", "Subscription", "PaymentEvent"]
+__all__ = ["User", "Channel", "Plan", "Subscription", "PaymentEvent", "Post"]

--- a/backend/app/models/post.py
+++ b/backend/app/models/post.py
@@ -1,0 +1,14 @@
+from sqlalchemy import ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    channel_id: Mapped[int] = mapped_column(ForeignKey("channels.id", ondelete="CASCADE"))
+    author_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    content: Mapped[str] = mapped_column(Text())
+    type: Mapped[str] = mapped_column(String(50))

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class ChannelBase(BaseModel):
+    title: str
+    is_private: bool = False
+
+
+class ChannelCreate(ChannelBase):
+    pass
+
+
+class ChannelRead(ChannelBase):
+    id: int
+    creator_id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/app/schemas/post.py
+++ b/backend/app/schemas/post.py
@@ -1,0 +1,21 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class PostBase(BaseModel):
+    channel_id: int
+    content: str
+    type: Literal["general", "stock-briefing"]
+
+
+class PostCreate(PostBase):
+    pass
+
+
+class PostRead(PostBase):
+    id: int
+    author_id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/migrations/versions/0003_create_posts.py
+++ b/backend/migrations/versions/0003_create_posts.py
@@ -1,0 +1,33 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "posts",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "channel_id",
+            sa.Integer,
+            sa.ForeignKey("channels.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "author_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("type", sa.String(50), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("posts")

--- a/frontend/app/(dashboard)/posts/[id]/edit/page.tsx
+++ b/frontend/app/(dashboard)/posts/[id]/edit/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function EditPostPage({ params }: { params: { id: string } }) {
+  const [channelId, setChannelId] = useState('');
+  const [content, setContent] = useState('');
+  const [type, setType] = useState('general');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch(`/api/v1/posts/${params.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ channel_id: Number(channelId), content, type }),
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <input
+        type="number"
+        placeholder="Channel ID"
+        value={channelId}
+        onChange={(e) => setChannelId(e.target.value)}
+        className="border p-2"
+        required
+      />
+      <textarea
+        placeholder="Content"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        className="border p-2"
+        required
+      />
+      <select
+        value={type}
+        onChange={(e) => setType(e.target.value)}
+        className="border p-2"
+      >
+        <option value="general">General</option>
+        <option value="stock-briefing">Stock Briefing</option>
+      </select>
+      <button type="submit" className="bg-blue-500 text-white p-2">
+        Update Post
+      </button>
+    </form>
+  );
+}

--- a/frontend/app/(dashboard)/posts/new/page.tsx
+++ b/frontend/app/(dashboard)/posts/new/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function NewPostPage() {
+  const [channelId, setChannelId] = useState('');
+  const [content, setContent] = useState('');
+  const [type, setType] = useState('general');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch('/api/v1/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ channel_id: Number(channelId), content, type }),
+    });
+    setChannelId('');
+    setContent('');
+    setType('general');
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <input
+        type="number"
+        placeholder="Channel ID"
+        value={channelId}
+        onChange={(e) => setChannelId(e.target.value)}
+        className="border p-2"
+        required
+      />
+      <textarea
+        placeholder="Content"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        className="border p-2"
+        required
+      />
+      <select
+        value={type}
+        onChange={(e) => setType(e.target.value)}
+        className="border p-2"
+      >
+        <option value="general">General</option>
+        <option value="stock-briefing">Stock Briefing</option>
+      </select>
+      <button type="submit" className="bg-blue-500 text-white p-2">
+        Create Post
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add role helper and subscriber guard
- implement channel and post CRUD APIs with stock-briefing post type
- expose post creation and editing pages on the dashboard

## Testing
- `pytest backend/tests/test_subscription.py`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bf853a883338c69455c2f036692