### PR TITLE
feat: add channel and post skeleton

### DIFF
--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -1,0 +1,31 @@
+"""Channel API endpoints.
+
+Provides access to channel listings.
+"""
+
+from fastapi import APIRouter, Request
+
+from app.core.logger import write_log
+from app.core.constants import DEFAULT_CHANNEL_ID
+
+router = APIRouter(prefix="/channels", tags=["channels"])
+
+CHANNELS = [
+    {"id": DEFAULT_CHANNEL_ID, "name": "alpha", "description": "demo"}
+]
+
+
+@router.get("/")
+async def list_channels(request: Request) -> list[dict[str, int | str]]:
+    """Return available channels.
+
+    Args:
+        request: Incoming HTTP request.
+
+    Returns:
+        List of channels.
+    """
+    response_data = CHANNELS
+    log_text = f"REQUEST {request.method} {request.url}\nRESPONSE {response_data}"
+    write_log("channels", log_text)
+    return response_data

--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -1,0 +1,39 @@
+"""Post API endpoints.
+
+Provides access to posts within a channel.
+"""
+
+from fastapi import APIRouter, Request
+
+from app.core.constants import DEFAULT_CHANNEL_ID, DEFAULT_POST_ID
+from app.core.logger import write_log
+
+router = APIRouter(prefix="/channels/{channel_id}/posts", tags=["posts"])
+
+POSTS = {
+    DEFAULT_CHANNEL_ID: [
+        {
+            "id": DEFAULT_POST_ID,
+            "channel_id": DEFAULT_CHANNEL_ID,
+            "title": "welcome",
+            "content": "hello",
+        }
+    ]
+}
+
+
+@router.get("/")
+async def list_posts(channel_id: int, request: Request) -> list[dict[str, int | str]]:
+    """Return posts for a channel.
+
+    Args:
+        channel_id: Identifier of the channel.
+        request: Incoming HTTP request.
+
+    Returns:
+        List of posts in the channel.
+    """
+    response_data = POSTS.get(channel_id, [])
+    log_text = f"REQUEST {request.method} {request.url}\nRESPONSE {response_data}"
+    write_log("posts", log_text)
+    return response_data

--- a/backend/app/core/constants.py
+++ b/backend/app/core/constants.py
@@ -1,0 +1,8 @@
+"""Common constants for the backend.
+
+This module stores constant values used across multiple modules to avoid
+magic numbers.
+"""
+
+DEFAULT_CHANNEL_ID = 1
+DEFAULT_POST_ID = 1

--- a/backend/app/core/logger.py
+++ b/backend/app/core/logger.py
@@ -1,0 +1,32 @@
+"""Simple logging utility.
+
+Provides a helper to save debug logs into the logs directory with a
+module-specific filename and timestamp.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+TIME_FMT = "%m%d%H%M"
+BASE_DIR = Path(__file__).resolve().parents[3]
+LOG_DIR = BASE_DIR / "logs"
+LOG_DIR.mkdir(exist_ok=True)
+
+
+def write_log(module_name: str, content: str) -> None:
+    """Write content to a log file.
+
+    Args:
+        module_name: Module name used for the log filename.
+        content: Text to record.
+
+    Returns:
+        None
+    """
+    timestamp = datetime.now().strftime(TIME_FMT)
+    file_path = LOG_DIR / f"{module_name}{timestamp}.log"
+    try:
+        with file_path.open("w", encoding="utf-8") as log_file:
+            log_file.write(content)
+    except OSError as err:
+        print(f"log write failed: path={file_path}, error={err}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 
 from .core.config import settings
 
-from .api import auth, payments, subscriptions
+from .api import auth, payments, subscriptions, channels, posts
 
 
 app = FastAPI(title="Layer01 API")
@@ -11,6 +11,8 @@ app = FastAPI(title="Layer01 API")
 app.include_router(auth.router)
 app.include_router(subscriptions.router, prefix="/api/v1")
 app.include_router(payments.router, prefix="/api/v1")
+app.include_router(channels.router, prefix="/api/v1")
+app.include_router(posts.router, prefix="/api/v1")
 
 
 @app.get("/")

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1,0 +1,25 @@
+"""Tests for channel and post endpoints."""
+
+from fastapi.testclient import TestClient
+
+from app.core.constants import DEFAULT_CHANNEL_ID, DEFAULT_POST_ID
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_list_channels() -> None:
+    """Ensure channel list returns default channel."""
+    response = client.get("/api/v1/channels")
+    assert response.status_code == 200
+    data = response.json()
+    assert any(ch["id"] == DEFAULT_CHANNEL_ID for ch in data)
+
+
+def test_list_posts() -> None:
+    """Ensure posts list returns default post for channel."""
+    response = client.get(f"/api/v1/channels/{DEFAULT_CHANNEL_ID}/posts")
+    assert response.status_code == 200
+    data = response.json()
+    if data:
+        assert data[0]["id"] == DEFAULT_POST_ID

--- a/frontend/app/(public)/channels/page.tsx
+++ b/frontend/app/(public)/channels/page.tsx
@@ -1,0 +1,31 @@
+/**
+ * ChannelListPage fetches and displays channels.
+ */
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type Channel = {
+  id: number;
+  name: string;
+  description: string;
+};
+
+export default function ChannelListPage() {
+  const [channels, set_channels] = useState<Channel[]>([]);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/api/v1/channels')
+      .then((res) => res.json())
+      .then((data: Channel[]) => set_channels(data))
+      .catch(() => set_channels([]));
+  }, []);
+
+  return (
+    <ul>
+      {channels.map((ch) => (
+        <li key={ch.id}>{ch.name}</li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/app/(public)/page.tsx
+++ b/frontend/app/(public)/page.tsx
@@ -1,3 +1,13 @@
+/**
+ * PublicPage shows the landing page with a link to channels.
+ */
+import Link from 'next/link';
+
 export default function PublicPage() {
-  return <h1>Welcome to the public page</h1>;
+  return (
+    <div>
+      <h1>Welcome to the public page</h1>
+      <Link href="/channels">Channels</Link>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add simple channel and post APIs with log writer
- wire routers and provide constants
- add minimal frontend channel list page

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab487f804c833386b0eba8081d1f88